### PR TITLE
[NGC-4548] Updated to Play 2.6

### DIFF
--- a/app/uk/gov/hmrc/mobileauthstub/controllers/AuthStubController.scala
+++ b/app/uk/gov/hmrc/mobileauthstub/controllers/AuthStubController.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.mobileauthstub.controllers
 
-import javax.inject.Singleton
+import javax.inject.{Inject, Singleton}
 import play.api.mvc._
 import uk.gov.hmrc.mobileauthstub.views.html.sign_in_response
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
@@ -24,10 +24,10 @@ import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import scala.concurrent.Future
 
 @Singleton()
-class AuthStubController extends FrontendController {
+class AuthStubController @Inject()(cc: MessagesControllerComponents)
+  extends FrontendController(cc) {
 
-  def signIn(): Action[AnyContent] = Action.async { implicit request =>
+  def signIn(): Action[AnyContent] = Action.async { implicit request: MessagesRequest[AnyContent] =>
     Future successful Ok(sign_in_response())
   }
-
 }

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,6 @@ val appName: String = "mobile-auth-stub"
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(Seq(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory): _*)
   .settings(publishingSettings: _*)
-  .settings(routesGenerator := StaticRoutesGenerator)
   .settings(
     majorVersion := 0,
     scalaVersion := "2.11.12",

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,3 +1,3 @@
 # microservice specific routes
 
-GET        /gg/sign-in             @uk.gov.hmrc.mobileauthstub.controllers.AuthStubController.signIn()
+GET        /gg/sign-in             uk.gov.hmrc.mobileauthstub.controllers.AuthStubController.signIn()

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -2,4 +2,4 @@
 ->         /                     app.Routes
 ->         /                     health.Routes
 
-GET        /admin/metrics        @com.kenshoo.play.metrics.MetricsController.metrics
+GET        /admin/metrics        com.kenshoo.play.metrics.MetricsController.metrics

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,26 +1,26 @@
 import play.core.PlayVersion
-import play.sbt.PlayImport._
 import sbt._
 
 object AppDependencies {
 
-  private val play25Bootstrap = "4.6.0"
-  private val hmrcTestVersion = "3.3.0"
-  private val scalaTestVersion = "3.0.5"
-  private val pegdownVersion = "1.6.0"
+  private val play26Bootstrap          = "0.34.0"
+  private val hmrcTestVersion          = "3.4.0-play-26"
+  private val scalaTestVersion         = "3.0.5"
+  private val scalaTestPlusPlayVersion = "3.1.2"
+  private val pegdownVersion           = "1.6.0"
+  private val scalaMockVersion         = "4.1.0"
 
   val compile: Seq[ModuleID] = Seq(
-    ws,
-    "uk.gov.hmrc" %% "bootstrap-play-25" % play25Bootstrap
+    "uk.gov.hmrc" %% "bootstrap-play-26" % play26Bootstrap
   )
 
-  def test(scope: String): Seq[ModuleID] = Seq(
-    "uk.gov.hmrc" %% "hmrctest" % hmrcTestVersion % scope,
-    "org.pegdown" % "pegdown" % pegdownVersion % scope,
-    "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
-    "org.scalatest" %% "scalatest" % scalaTestVersion % scope
-  )
+  def test(scope: String): Seq[ModuleID] = {
+    Seq(
+      "uk.gov.hmrc" %% "hmrctest" % hmrcTestVersion % scope,
+      "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
+      "org.scalatest" %% "scalatest" % scalaTestVersion % scope
+    )
+  }
 
   def apply(): Seq[ModuleID] = compile ++ test("test")
-
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,6 +12,4 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.2.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.14.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.19")
-
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.4")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.21")

--- a/test/uk/gov/hmrc/mobileauthstub/controllers/AuthStubControllerSpec.scala
+++ b/test/uk/gov/hmrc/mobileauthstub/controllers/AuthStubControllerSpec.scala
@@ -17,15 +17,33 @@
 package uk.gov.hmrc.mobileauthstub.controllers
 
 import play.api.http.Status
+import play.api.mvc._
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.mobileauthstub.views.html.sign_in_response
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import uk.gov.hmrc.play.test.UnitSpec
 
-class AuthStubControllerSpec extends UnitSpec with WithFakeApplication {
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContext.Implicits.global
 
-  val fakeRequest = FakeRequest("GET", "/gg/sign-in")
-  val controller = new AuthStubController()
+class AuthStubControllerSpec extends UnitSpec {
+
+  private val messagesActionBuilder: MessagesActionBuilder = new DefaultMessagesActionBuilderImpl(stubBodyParser[AnyContent](), stubMessagesApi())
+  private val cc                                           = stubControllerComponents()
+
+  private val mcc: MessagesControllerComponents = DefaultMessagesControllerComponents(
+    messagesActionBuilder,
+    DefaultActionBuilder(stubBodyParser[AnyContent]()),
+    cc.parsers,
+    cc.messagesApi,
+    cc.langs,
+    cc.fileMimeTypes,
+    ExecutionContext.global
+  )
+
+  val controller = new AuthStubController(mcc)
+
+  val fakeRequest: FakeRequest[AnyContent] = FakeRequest("GET", "/gg/sign-in")
 
   "GET /gg/sign-in" should {
     "return 200 and an html page with a success code" in {


### PR DESCRIPTION
I spent a lot of time trying to figure out how to create an instance of `MessagesControllerComponents`, required by `AuthStubController`. The result is in `AuthStubControllerSpec` and is as small as I could boil it down to. Since all controllers that extend `FrontendController` for Play 2.6 are going to need this I suggest we extract it to a library (ideally `hmrctest`) so that other projects can avoid the boilerplate.