### PR TITLE
[NGC-4685] I've updated the `sign_in_response` template to include th…

### DIFF
--- a/app/uk/gov/hmrc/mobileauthstub/views/sign_in_response.scala.html
+++ b/app/uk/gov/hmrc/mobileauthstub/views/sign_in_response.scala.html
@@ -16,6 +16,12 @@
 
 <html>
     <head>
-        <meta http-equiv="content-type" content="text/html; charset=UTF-8"/> <title>Success code=sandboxSuccess</title>
+        <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
+        <title>Success code=sandboxSuccess</title>
     </head>
+    <body>
+        <header>
+            <h1>sign in</h1>
+        </header>
+    </body>
 </html>


### PR DESCRIPTION
…e header that the integration tests look for to check that the right redirect has happened from `mobile-token-proxy`

This is one of three pull requests to fix this, the others being to `service-manager-config` and `next-generation-consumer-acceptance-tests`. It's safe to merge this one first in readiness for the others.